### PR TITLE
Fix support for SIGNALFX_SEND_TIMEOUT

### DIFF
--- a/signalfx_lambda/metrics.py
+++ b/signalfx_lambda/metrics.py
@@ -2,12 +2,13 @@ import functools
 import signalfx
 import os
 import datetime
+import six
 
 from . import utils
 from .version import name, version
 
 ingest_endpoint = utils.get_metrics_url()
-ingest_timeout = os.environ.get('SIGNALFX_SEND_TIMEOUT', 0.3)
+ingest_timeout = float(os.environ.get('SIGNALFX_SEND_TIMEOUT', 0.3))
 
 sfx = signalfx.SignalFx(ingest_endpoint=ingest_endpoint)
 
@@ -123,14 +124,7 @@ def wrapper(*args, **kwargs):
             default_dimensions.update(dimensions)
 
         token = kwargs.get('access_token')
-        if isstr(token):
+        if isinstance(token, six.string_types):
             access_token = token
 
         return generate_wrapper_decorator(access_token)
-
-def isstr(s):
-    try:
-        basestring
-    except NameError:
-        basestring = str
-    return isinstance(s, basestring)

--- a/signalfx_lambda/version.py
+++ b/signalfx_lambda/version.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2017 SignalFx, Inc. All rights reserved.
 
 name = 'signalfx_lambda'
-version = '0.2.0'
+version = '0.2.1'
 
 user_agent = 'signalfx_lambda/' + version


### PR DESCRIPTION
Properly convert SIGNALFX_SEND_TIMEOUT value to float.
Additionally simplify isstr checkj with six.