### PR TITLE
SIGNALFX_ENVIRONMENT env variable tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,11 @@ To learn more, see:
     SIGNALFX_TRACING_URL=tracing endpoint [ default: https://ingest.signalfx.com/v1/trace ]
     
 
+4. (Optional) Set environment variable to set `environment` root span tag
+
+.. code:: bash
+    SIGNALFX_ENVIRONMENT=production
+
 Step 4: Wrap a function
 --------------------------
 
@@ -291,6 +296,9 @@ The tracing wrapper creates a span for the wrapper handler. This span contains t
 +----------------------------------+----------------------------------+
 | component                        | The literal value of             |
 |                                  | ‘python-lambda-wrapper’          |
++----------------------------------+----------------------------------+
+| environment                      | Environment name defined by      |
+|                                  | SIGNALFX_ENVIRONMENT             |
 +----------------------------------+----------------------------------+
 
 

--- a/signalfx_lambda/tracing.py
+++ b/signalfx_lambda/tracing.py
@@ -17,6 +17,11 @@ def wrapper(func):
         span_tags['component'] = 'python-lambda-wrapper'
         span_tags[ext_tags.SPAN_KIND] = ext_tags.SPAN_KIND_RPC_SERVER
 
+        environment = os.getenv('SIGNALFX_ENVIRONMENT')
+
+        if environment:
+            span_tags['environment'] = environment
+
         span_prefix = os.getenv('SIGNALFX_SPAN_PREFIX', 'lambda_python_')
 
         try:


### PR DESCRIPTION
v2.0 of the APM requires a span tag of `environment` to be set in order to logically categorize service maps. This PR allows optional setting of the `environment` tag by setting an environment variable of `SIGNALFX_ENVIRONMENT` and using its value as the tag value.