### PR TITLE
Add context propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 .idea
 *.iml
+.vscode
+venv
 dist
 build
 *.egg-info

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ The decorators can be used individually or together.
 
     import signalfx_lambda
 
-    @signalfx_lambda.emits_metrics
+    @signalfx_lambda.emits_metrics()
     def handler(event, context):
         # your code
 
@@ -143,9 +143,23 @@ The decorators can be used individually or together.
 
     import signalfx_lambda
 
-    @signalfx_lambda.is_traced
+    @signalfx_lambda.is_traced()
     def handler(event, context):
         # your code
+
+3. Optionally, you can tell the wrapper to not auto-create a span but still initialize tracing for manual usage.
+
+This is useful when processing SQS messages and you want each message to tie to the trace from producer that emitted the message.
+
+.. code:: python
+
+    import signalfx_lambda
+
+    @signalfx_lambda.is_traced(with_span=False)
+    def handler(event, context):
+        for record in event.get('Records', []):
+            with signalfx_lambda.create_span(record, context):
+                # your code to process record
 
 
 Step 5: Send custom metrics from a Lambda function

--- a/signalfx_lambda/__init__.py
+++ b/signalfx_lambda/__init__.py
@@ -7,17 +7,16 @@ from . import tracing
 from .version import name, version
 
 
-# backwards compatibility
-def wrapper(*args, **kwargs):
-    return metrics.wrapper(*args, **kwargs)
-
-
 def emits_metrics(*args, **kwargs):
     return metrics.wrapper(*args, **kwargs)
 
 
 def is_traced(*args, **kwargs):
     return tracing.wrapper(*args, **kwargs)
+
+
+# backwards compatibility
+wrapper = emits_metrics
 
 
 # less convenient method

--- a/signalfx_lambda/metrics.py
+++ b/signalfx_lambda/metrics.py
@@ -108,23 +108,25 @@ def generate_wrapper_decorator(access_token):
     return wrapper_decorator
 
 
-def wrapper(*args, **kwargs):
-    access_token = utils.get_access_token()
-    if len(args) == 1 and callable(args[0]):
-        # plain wrapper with no parameter
-        # call the wrapper decorator like normally would
-        decorator = generate_wrapper_decorator(access_token)
-        return decorator(args[0])
-    else:
-        dimensions = kwargs.get('dimensions')
-        if isinstance(dimensions, dict):
-            # wrapper with dimension parameter
-            # assign default dimensions
-            # then return the wrapper decorator
-            default_dimensions.update(dimensions)
+def wrapper():
+    def inner(*args, **kwargs):
+        access_token = utils.get_access_token()
+        if len(args) == 1 and callable(args[0]):
+            # plain wrapper with no parameter
+            # call the wrapper decorator like normally would
+            decorator = generate_wrapper_decorator(access_token)
+            return decorator(args[0])
+        else:
+            dimensions = kwargs.get('dimensions')
+            if isinstance(dimensions, dict):
+                # wrapper with dimension parameter
+                # assign default dimensions
+                # then return the wrapper decorator
+                default_dimensions.update(dimensions)
 
-        token = kwargs.get('access_token')
-        if isinstance(token, six.string_types):
-            access_token = token
+            token = kwargs.get('access_token')
+            if isinstance(token, six.string_types):
+                access_token = token
 
-        return generate_wrapper_decorator(access_token)
+            return generate_wrapper_decorator(access_token)
+    return inner

--- a/signalfx_lambda/version.py
+++ b/signalfx_lambda/version.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2017 SignalFx, Inc. All rights reserved.
 
 name = 'signalfx_lambda'
-version = '0.2.1'
+version = '1.0.0beta1'
 
 user_agent = 'signalfx_lambda/' + version


### PR DESCRIPTION
This commit adds the following new features:

1. HTTP context propagation

The wrapper now automatically tries to extract B3 tracing headers from
incoming HTTP requests and uses the extracted span context as the parent
span when creating new spans.

2. Allows users to initialize the tracing without auto-creating the span

The decorator now must be called and accepts an optional argument
`with_span=<bool>` which defaults to `True`. When set to `False`, the
wrapper still initializes and flushes the tracer but does not auto
create spans. To keep things consistent, this also updates the metrics wrapper
to behave similarly although it doesn't accept any args. 