### PR TITLE
Add support for auto-instrumentation and flushing spans

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,6 +329,36 @@ The tracing wrapper creates a span for the wrapper handler. This span contains t
 
 
 
+Auto-instrumentation packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The SignalFx Python Lambda Wrapper can automatically instrument supported packages. All you need to do is to install instrumentations you need in addition to `signalfx_lambda`. Below is a list of all instrumentation packages supported:
+
++--------------------------+----------------------------------------------------------------------------------------------------+
+| Library/Framework        | Instrumentation Package                                                                            |
++==========================+====================================================================================================+
+| celery                   | `https://github.com/signalfx/python-celery/tarball/0.0.1post0#egg=celery-opentracing`              |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| django                   | `https://github.com/signalfx/python-django/tarball/0.1.18post1#egg=django-opentracing`             |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| elasticsearch            | `https://github.com/signalfx/python-elasticsearch/tarball/0.1.4post#egg=elasticsearch-opentracing` |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| flask                    | `https://github.com/signalfx/python-flask/tarball/1.1.0post1#egg=flask_opentracing`                |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| psycopg                  | `https://github.com/signalfx/python-dbapi/tarball/v0.0.5post1#egg=dbapi-opentracing`               |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| pymongo                  | `https://github.com/signalfx/python-pymongo/tarball/v0.0.3post1#egg=pymongo-opentracing`           |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| pymysql                  | `https://github.com/signalfx/python-dbapi/tarball/v0.0.5post1#egg=dbapi-opentracing`               |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| redis                    | `https://github.com/signalfx/python-redis/tarball/v1.0.0post1#egg=redis-opentracing`               |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| requests                 | `https://github.com/signalfx/python-requests/archive/v0.2.0post1.zip#egg=requests-opentracing`     |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| tornado                  | `https://github.com/signalfx/python-tornado/archive/1.0.1post1.zip#egg=tornado_opentracing`        |
++--------------------------+----------------------------------------------------------------------------------------------------+
+
+
 Test locally 
 ^^^^^^^^^^^^^^^^^
 If you would like to test changes to a wrapper, run the following commands in your command line: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 signalfx>=1.0.16
-sfx-jaeger-client>=3.13.1b0.dev4
+signalfx-tracing>=1.5.1
 six>=1.4.0


### PR DESCRIPTION
This adds the following improvements:

1. It avoids closing and re-creating the tracer for every request and instead uses the new blocking `tracer.flush()` method.
2. It tries to auto-instrument package after initializing the tracer.

Depends on newer, yet to be released version of sfx-jaeger-client.